### PR TITLE
Add current day

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,1 +1,3 @@
-console.log(moment().format("MMMM Do YYYY, h:mm:ss a"));
+var currentDay = $("#currentDay")
+
+currentDay.text(moment().format("dddd MMMM Do"))


### PR DESCRIPTION
Display the current day at the top of the calendar when a user opens the planner.